### PR TITLE
Forcing last Cypress test to be recorded

### DIFF
--- a/R/utils_cypress.R
+++ b/R/utils_cypress.R
@@ -144,6 +144,8 @@ create_cypress_tests <- function(project_path, cypress_file) {
 add_sendtime2js <- function(js_file, txt_file) {
   lines_to_add <- glue(
     "
+  describe('Finalizing tests', () => {it('Ending tests', () => {})})
+
   // Returning the time for each test
   // https://www.cypress.io/blog/2020/05/22/where-does-the-test-spend-its-time/
   let commands = []
@@ -169,7 +171,6 @@ add_sendtime2js <- function(js_file, txt_file) {
   }
   // Calling the sendTestTimings function
   beforeEach(sendTestTimings)
-  after(sendTestTimings)
   ",
     .open = "{{", .close = "}}"
   )


### PR DESCRIPTION
### Link to the Issue

close #27 

The solution is a workaround. It seems that the Cypress `after` function is being trigger with some lag. As a result, the last test is not being recorded. See this question http://disq.us/p/2rdi35j in the post used as example for our implementation.

### Definition of Done

All tests written in the Cypress file should be recorded.

### How to test changes

Run the example in the zip file. The output should contain all the tests in the Cypress file.

[app.zip](https://github.com/Appsilon/experimental.performance/files/9853121/app.zip)



### Tasks for PR author

- [x] Test your change and ensure there is no regression
- [x] Change has a corresponding issue. ***Ensure it is linked in GitHub***
- [x] Author of the change opened a pull request and assigned a reviewer

### General policy:

- If applicable - add instructions for testing
- If there’s no issue, create it. Each issue needs to be well defined and described.
- All interaction with a user, user-facing messages, plots, reports etc. are written from the perspective of the person using or receiving it. They are understandable and helpful to this person. If a user sees an error message, there is a call to action, i.e. the user knows what to do to fix it.
- README, other documentation and code comments that we have is updated with all information related to the change.
- All code has been peer-reviewed before merging into any main branch
- All changes have been merged into the main branch we use for development.
- Continuous integration checks (linter, unit tests, integration tests) are configured and pass.
- Optional: unit tests added for all new or changed logic.
- All task requirements satisfied. If not describe it here. The reviewer is responsible to verify each aspect of the task.
- Change covers only things in task. Please create new PR if you want to fix something else.
