### PR TITLE
Migrate load_examples to use fs library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Suggests:
   knitr,
   lintr,
   rcmdcheck,
+  mockr,
   spelling
 Imports:
   dplyr,

--- a/man/load_example.Rd
+++ b/man/load_example.Rd
@@ -4,10 +4,12 @@
 \alias{load_example}
 \title{Load an application and instructions to run shiny.benchmark}
 \usage{
-load_example(path)
+load_example(path, force = FALSE)
 }
 \arguments{
 \item{path}{A character vector of full path name}
+
+\item{force}{Create example even if directory does not exist or is not empty}
 }
 \description{
 This function aims to generate a template to be used
@@ -16,4 +18,7 @@ some examples of tests using Cypress and shinytest2. Also, a simple
 application will be added to the folder as well as instructions on how
 to perform the performance checks. Be aware that a new git repo is need in
 the selected \code{path}.
+}
+\examples{
+load_example(file.path(tempdir(), "example_destination"), force = TRUE)
 }

--- a/tests/testthat/test-load_example.R
+++ b/tests/testthat/test-load_example.R
@@ -82,4 +82,3 @@ test_that("Does not create load_examples if there is a file in directory", {
       expect_output("app created at")
   })
 })
-

--- a/tests/testthat/test-load_example.R
+++ b/tests/testthat/test-load_example.R
@@ -1,0 +1,85 @@
+# Necessary test as fs::dir_copy with overwrite has a different behavior
+#  than file.copy.
+# It copies the content of the directory of the  "from" path into the
+#  destination, instead of the directory itself
+test_that("Load example creates correct structure", {
+  example_path <- fs::path(tempdir(), "load_example")
+  fs::dir_create(example_path)
+  local({
+    local_mock(menu = function(...) stop("Opps, shouldn't reach this"))
+    load_example(example_path, force = TRUE)
+  })
+
+  files <- example_path |>
+    fs::path(
+      c(
+        "run_tests.R",
+        fs::path("app", "ui.R"),
+        fs::path("app", "server.R"),
+        fs::path("app", "global.R"),
+        fs::path("app", "tests", "testthat.R"),
+        fs::path("app", "tests", "testthat", "setup.R"),
+        fs::path("app", "tests", "testthat", "test-use_this_one_1.R"),
+        fs::path("app", "tests", "testthat", "test-use_this_one_2.R")
+      )
+    )
+
+  dirs <- example_path |>
+    fs::path(
+      c(
+        fs::path("app", "tests"),
+        fs::path("app", "tests", "cypress"),
+        fs::path("app", "tests", "testthat")
+      )
+    )
+
+  expect_true(all(fs::file_exists(files)))
+  expect_true(all(fs::is_file(files)))
+  expect_false(all(fs::is_dir(files)))
+
+  expect_true(all(fs::dir_exists(dirs)))
+  expect_true(all(fs::is_dir(dirs)))
+  expect_false(all(fs::is_file(dirs)))
+})
+
+test_that("Does not create load_examples on non-existing directory", {
+  example_path <- fs::path(
+    tempdir(),
+    glue::glue("load_example_not_existing{unclass(Sys.time())}")
+  )
+
+  local({
+    local_mock(menu = function(...) stop("Opps, shouldn't reach this"))
+    load_example(example_path) |>
+      expect_error("You must provide a valid path")
+  })
+
+  fs::dir_create(example_path)
+  local({
+    local_mock(menu = function(...) stop("Opps, shouldn't reach this"))
+    load_example(example_path) |>
+      expect_output("app created at")
+  })
+})
+
+test_that("Does not create load_examples if there is a file in directory", {
+  example_path <- fs::path(
+    tempdir(),
+    glue::glue("load_example_not_empty{unclass(Sys.time())}")
+  )
+  fs::dir_create(example_path)
+  fs::file_create(fs::path(example_path, "touch.txt"))
+
+  local({
+    local_mock(menu = function(...) 2)
+    load_example(example_path) |>
+      expect_error("Consider creating a new empty path.")
+  })
+
+  local({
+    local_mock(menu = function(...) 1)
+    load_example(example_path) |>
+      expect_output("app created at")
+  })
+})
+


### PR DESCRIPTION
### Link to the Issue

- #91 

### Definition of Done

Can the load_examples data structure be created with `fs` library

### How to test changes

Run unit tests and use the `shiny.benchmark::load_examples()` function

- Parameter `force = TRUE` will just force through it if the directory doesn't exists or is non-empty
- check if the file structure is the same as `inst/examples`

### Tasks for PR author

- [x] Test your change and ensure there is no regression
- [x] Change has a corresponding issue. ***Ensure it is linked in GitHub***
- [x] Author of the change opened a pull request and assigned a reviewer

### General policy:

- If applicable - add instructions for testing
- If there’s no issue, create it. Each issue needs to be well defined and described.
- All interaction with a user, user-facing messages, plots, reports etc. are written from the perspective of the person using or receiving it. They are understandable and helpful to this person. If a user sees an error message, there is a call to action, i.e. the user knows what to do to fix it.
- README, other documentation and code comments that we have is updated with all information related to the change.
- All code has been peer-reviewed before merging into any main branch
- All changes have been merged into the main branch we use for development.
- Continuous integration checks (linter, unit tests, integration tests) are configured and pass.
- Optional: unit tests added for all new or changed logic.
- All task requirements satisfied. If not describe it here. The reviewer is responsible to verify each aspect of the task.
- Change covers only things in task. Please create new PR if you want to fix something else.

closes #91
