### PR TITLE
`shiny` -> 'shiny' and adding return for load_example function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: shiny.benchmark
-Title: Benchmark the Performance of `shiny` Applications
+Title: Benchmark the Performance of 'shiny' Applications
 Version: 0.1.1
 Authors@R:
   c(
     person(given = "Douglas", family = "Azevedo", email = "opensource+douglas@appsilon.com", role = c("aut", "cre")),
     person(family = "Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
   )
-Description: Compare performance between different versions of a `shiny` application based on `git` references.
+Description: Compare performance between different versions of a 'shiny' application based on 'git' references.
 License: LGPL-3
 URL: https://github.com/Appsilon/shiny.benchmark, https://github.com/Appsilon/shiny.benchmark
 BugReports: https://github.com/Appsilon/shiny.benchmark/issues

--- a/R/utils.R
+++ b/R/utils.R
@@ -180,6 +180,8 @@ summarise_commit <- function(object) {
 #' @param path A character vector of full path name
 #' @param force Create example even if directory does not exist or is not empty
 #'
+#' @return Print on the console instructions to run the example
+#'
 #' @importFrom glue glue
 #' @importFrom utils menu
 #' @export

--- a/man/load_example.Rd
+++ b/man/load_example.Rd
@@ -11,6 +11,9 @@ load_example(path, force = FALSE)
 
 \item{force}{Create example even if directory does not exist or is not empty}
 }
+\value{
+Print on the console instructions to run the example
+}
 \description{
 This function aims to generate a template to be used
 by shiny.benchmark. It will create the necessary structure on \code{path} with


### PR DESCRIPTION
### Definition of Done

Please use only undirected quotation marks in the description text.
e.g. `shiny` --> 'shiny'

There is still one \value-/@return-tag missing.
Missing Rd-tags:
      load_example.Rd: \value

### Tasks for PR author

- [x] Test your change and ensure there is no regression
- [x] Change has a corresponding issue. ***Ensure it is linked in GitHub***
- [x] Author of the change opened a pull request and assigned a reviewer

### General policy:

- If applicable - add instructions for testing
- If there’s no issue, create it. Each issue needs to be well defined and described.
- All interaction with a user, user-facing messages, plots, reports etc. are written from the perspective of the person using or receiving it. They are understandable and helpful to this person. If a user sees an error message, there is a call to action, i.e. the user knows what to do to fix it.
- README, other documentation and code comments that we have is updated with all information related to the change.
- All code has been peer-reviewed before merging into any main branch
- All changes have been merged into the main branch we use for development.
- Continuous integration checks (linter, unit tests, integration tests) are configured and pass.
- Optional: unit tests added for all new or changed logic.
- All task requirements satisfied. If not describe it here. The reviewer is responsible to verify each aspect of the task.
- Change covers only things in task. Please create new PR if you want to fix something else.
